### PR TITLE
Email to username

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -20,7 +20,7 @@
       %section
         %p This is login page for users.
         %form{ action: '/login', method: 'POST' } 
-          %input{type: 'text', name: 'username', placeholder: 'Email here'}
+          %input{type: 'text', name: 'username', placeholder: 'Username here'}
           %br
           %input{type: 'text', name: 'password', placeholder: 'Password here'}
           %br


### PR DESCRIPTION
The field is named "username", but the text said "Email here". To prevent confusion when trying to find the field with Capybara (`fill_in("email", ...)` returns an error), I changed it to say "Username here".