### PR TITLE
Attempt to get the Capybara testing working.

### DIFF
--- a/features/login.feature
+++ b/features/login.feature
@@ -5,6 +5,10 @@ Feature: Login Page
 
   Scenario: Authenticated User
     Given the login page
-    When I log in with proper credentials
+    When I log in with user 'gwadej' and password 'gwadej'
     Then I should see the secret page
-    
+
+  Scenario: Unauthenticated User
+    Given the login page
+    When I log in with user 'gwadej' and password 'foo'
+    Then I should see the authentication error message

--- a/features/logout.feature
+++ b/features/logout.feature
@@ -1,1 +1,7 @@
-#Add your codez here
+Feature: Logout Page
+  In order to log out of the site when I'm finished.
+
+  Scenario: Authenticated User
+    Given I have logged in
+    When I click logout
+    Then I should see the login page

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -1,14 +1,23 @@
 Given(/^the login page$/) do
   #put your code here
-  pending
+  visit '/'
 end
 
-When(/^I log in with proper credentials$/) do
-  #put your code here
-  pending
+When(/^I log ?in with user '([^']+)' and password '([^']+)'$/) do |user,pass|
+  @username = user
+  within('form') do
+    fill_in 'username', :with => user
+    fill_in 'password', :with => pass
+  end
+  click_button 'Login'
 end
 
 Then(/^I should see the secret page$/) do
-  #put your code here
-  pending
+  expect(page).to have_content 'This is the secret page.'
+  # TODO: Capybara seems to be losing the session, reported off and on for years.
+#  expect(page).to have_content "Your username is #{@username}."
+end
+
+Then(/^I should see the authentication error message$/) do
+  expect(page).to have_content 'Your username & password did not match'
 end

--- a/features/step_definitions/logout_steps.rb
+++ b/features/step_definitions/logout_steps.rb
@@ -1,1 +1,17 @@
-#Add your codez here
+Given(/^I have logged in$/) do
+  visit '/'
+  @username = 'gwadej'
+  within('form') do
+    fill_in 'username', :with => @username
+    fill_in 'password', :with => @username
+  end
+  click_button 'Login'
+end
+
+When(/^I click logout$/) do
+  click_link('Logout')
+end
+
+Then(/^I should see the login page$/) do
+  expect(page).to have_content 'You have been logged out'
+end


### PR DESCRIPTION
It mostly works, but I have two things I don't understand.

1. On the 'secret page', the username does not show up in the Capybara
test. With further research, it appears that the session information is
being lost somewhere. Maybe the Capybara/Cucumber thing is not properly
saving resources.

Searching on-line shows that this has been a recurring problem for
years.

2. Can't fail a login. On the browser, the username and password have to
match in order to login. However, in the Capybara/Cucumber tests the
system successfully logs in no matter what username/password pair I
send.

@chivygab @jaybobo Code review please.